### PR TITLE
Update : 중고거래 댓글 작성, 조회시 데이터 응답 구조 수정

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -47,7 +47,6 @@ urlpatterns = [
     path('api/boards/posts/comments-by-userid/<int:user_id>/', views.BoardCommentListByUserId.as_view(), name='board-comment-list-by-userid'),
     path('api/boards/posts/comments-by-postid/<int:post_id>/', views.BoardCommentListByPostId.as_view(), name='board-comment-list-by-postid'),
     path('api/boards/posts/comments-by-parent/<int:parent_comment>/', views.BoardCommentListByParent.as_view(), name='board-comment-list-by-parent'),
-    #path('api/boards/posts/comments/<int:post_id>/<int:user_id>/create/', views.BoardCommentCreate.as_view(), name='board-comment-create'),
     path('api/boards/posts/comments/create/', views.BoardCommentCreate.as_view(), name='board-comment-create'),
     path('api/boards/posts/comments/<int:pk>/update/', views.BoardCommentUpdate.as_view(), name='board-comment-update'),
     path('api/boards/posts/comments/<int:pk>/delete/', views.BoardCommentDelete.as_view(), name='board-comment-delete'),


### PR DESCRIPTION
[중고거래 댓글 생성]

- 생성 코드 수정
- 응답 데이터 구조 수정

[중고거래 댓글 조회]

- 장고 ORM 설정시 활용했던 replies 통해 효율적으로 대댓글 가져오도록 코드 작성
- 응답시, 부모 댓글에 comments 컬럼 추가하여 대댓글 리스트로 반환
- 응답 데이터에 유저의 학교이름, 학과이름, 입학년도 추가
- post-id 로 조회할 경우에만 으로 작성해둠